### PR TITLE
Couple of new features

### DIFF
--- a/cmd/asgs.go
+++ b/cmd/asgs.go
@@ -1,0 +1,26 @@
+// Copyright © 2018 Amit Saha <amitsaha.in@gmail.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/spf13/cobra"
+
+var asgCmd = &cobra.Command{
+	Use:   "auto-scaling-groups",
+	Short: "Commands for working with AWS Auto Scaling Groups",
+}
+
+func init() {
+	rootCmd.AddCommand(asgCmd)
+}

--- a/cmd/listAsg.go
+++ b/cmd/listAsg.go
@@ -67,5 +67,5 @@ var listAsgCmd = &cobra.Command{
 }
 
 func init() {
-	ec2Cmd.AddCommand(listAsgCmd)
+	asgCmd.AddCommand(listAsgCmd)
 }


### PR DESCRIPTION
The following changes are in this commit:

- `yawsi ec2 list-instances`: Add support for filtering by a `instance-id`
- `yawsi ec2 list-instances`: Add flag to show the tags of a insgance (most useful with `instance-id`)
- Move `yawsi ec2 list-asgs` to it's own command/sub-command: `yawsi auto-scaling-groups list-asgs`

The last is a breaking change, if you were using `yawsi ec2 list-asgs`, please change it to
`yawsi auto-scaling-groups list-asgs`